### PR TITLE
Tutorials

### DIFF
--- a/assets/controllers/tutorial_controller.js
+++ b/assets/controllers/tutorial_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    currentStep = null;
+    steps = [];
+
+    initialize() {
+        this.steps = document.getElementsByClassName('tutorialStep');
+        console.log(this.steps);
+    }
+
+    start() {
+        console.log('start');
+        this.currentStep = 0;
+        this.update();
+    }
+
+    next() {
+        this.currentStep++;
+        this.update();
+    }
+
+    prev() {
+        this.currentStep--;
+        this.update();
+    }
+
+    close() {
+        this.currentStep = null;
+        this.update();
+    }
+
+    update() {
+        for (let step of this.steps) {
+            step.classList.add('hidden');
+            step.classList.remove('block');
+        }
+
+        const step = this.steps[this.currentStep];
+        if (step === undefined) {
+            this.currentStep = null;
+        } else {
+            step.classList.remove('hidden');
+            step.classList.add('block');
+            step.scrollIntoView({
+                behavior: "smooth",
+                block: "center",
+            });
+        }
+    }
+}

--- a/assets/controllers/tutorial_controller.js
+++ b/assets/controllers/tutorial_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
 
     initialize() {
         this.steps = document.getElementsByClassName('tutorialStep');
-        console.log(this.steps);
     }
 
     start() {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -34,7 +34,7 @@
         {% endif -%}
 
     </head>
-    <body>
+    <body data-controller="tutorial">
     <nav class="bg-white shadow fixed top-0 w-full z-40" data-controller="visibility">
         <div class="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
             <div class="flex h-16 justify-between">
@@ -48,64 +48,70 @@
                     </div>
                 </div>
 
-                <div class="flex items-center lg:hidden">
-                    <!-- Mobile menu button -->
-                    <button type="button" data-action="visibility#toggleTargets" class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                        <span class="sr-only">Open main menu</span>
-                        <!--
-                          Icon when menu is closed.
+                <div class="flex flex-row">
+                    {% if showTutorial|default %}
+                        <button data-action="tutorial#start"><i class="fa-regular fa-question-circle text-gray-500 hover:text-gray-700"></i></button>
+                    {% endif %}
 
-                          Heroicon name: outline/bars-3
+                    <div class="flex items-center lg:hidden">
+                        <!-- Mobile menu button -->
+                        <button type="button" data-action="visibility#toggleTargets" class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+                            <span class="sr-only">Open main menu</span>
+                            <!--
+                              Icon when menu is closed.
 
-                          Menu open: "hidden", Menu closed: "block"
-                        -->
-                        <svg data-visibility-target="hideable" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-                        </svg>
-                        <!--
-                          Icon when menu is open.
+                              Heroicon name: outline/bars-3
 
-                          Heroicon name: outline/x-mark
+                              Menu open: "hidden", Menu closed: "block"
+                            -->
+                            <svg data-visibility-target="hideable" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                            </svg>
+                            <!--
+                              Icon when menu is open.
 
-                          Menu open: "block", Menu closed: "hidden"
-                        -->
-                        <svg data-visibility-target="hideable" class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                    </button>
-                </div>
-                <div class="hidden lg:ml-4 lg:flex lg:items-center">
+                              Heroicon name: outline/x-mark
 
-                    {#
-                    <button type="button" class="flex-shrink-0 rounded-full bg-white p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                        <span class="sr-only">View notifications</span>
-                        <!-- Heroicon name: outline/bell -->
-                        <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
-                        </svg>
-                    </button>
-                    #}
+                              Menu open: "block", Menu closed: "hidden"
+                            -->
+                            <svg data-visibility-target="hideable" class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="hidden lg:ml-4 lg:flex lg:items-center">
 
-                    <!-- Profile dropdown -->
-                    <div class="relative ml-4 flex-shrink-0">
+                        {#
+                        <button type="button" class="flex-shrink-0 rounded-full bg-white p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                            <span class="sr-only">View notifications</span>
+                            <!-- Heroicon name: outline/bell -->
+                            <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+                            </svg>
+                        </button>
+                        #}
 
-                        <div>
-                            {% if app.user %}
-                                <a href="{{ path('app_user') }}" class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-gray-500 hover:text-gray-700">
-                                    <i class="fa-solid fa-user-circle mr-1"></i> {{ app.user.name }}
-                                </a>
+                        <!-- Profile dropdown -->
+                        <div class="relative ml-4 flex-shrink-0">
 
-                                {#
-                                <span type="button" class="flex rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
-                                    <span class="sr-only">Open user menu</span>
-                                    <span class="h-8 w-8 rounded-full bg-gray-200"></span>
-                                </span>
-                                #}
-                            {% else %}
-                                <a href="{{ path('app_login') }}" class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-gray-500 hover:text-gray-700">
-                                    Anmelden
-                                </a>
-                            {% endif %}
+                            <div>
+                                {% if app.user %}
+                                    <a href="{{ path('app_user') }}" class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-gray-500 hover:text-gray-700">
+                                        <i class="fa-solid fa-user-circle mr-1"></i> {{ app.user.name }}
+                                    </a>
+
+                                    {#
+                                    <span type="button" class="flex rounded-full bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
+                                        <span class="sr-only">Open user menu</span>
+                                        <span class="h-8 w-8 rounded-full bg-gray-200"></span>
+                                    </span>
+                                    #}
+                                {% else %}
+                                    <a href="{{ path('app_login') }}" class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-gray-500 hover:text-gray-700">
+                                        Anmelden
+                                    </a>
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/templates/consultation/index.html.twig
+++ b/templates/consultation/index.html.twig
@@ -1,3 +1,4 @@
+{% set showTutorial = true %}
 {% extends 'layout-default.html.twig' %}
 
 {% block title %}Vernehmlassungsverfahren{% endblock %}
@@ -6,6 +7,8 @@
     <div class="bg-white">
         <div>
             <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                {{ block('step1', 'tutorials/consultations_index.tutorial.html.twig') }}
+
                 <div class="flex items-baseline justify-between pt-20 md:pt-16 pb-6">
                     <a href="{{ path('app_consultation') }}"><h1 class="text-2xl sm:text-3xl md:text-4xl xl:text-6xl font-bold tracking-tight text-gray-700 hover:text-gray-600">{{ 'consultation.procedures'|trans }}</h1></a>
                 </div>
@@ -13,6 +16,7 @@
                 {# Search #}
                 <div>
                     {{ component('search_consultations') }}
+                    {{ block('step2', 'tutorials/consultations_index.tutorial.html.twig') }}
                 </div>
 
 
@@ -43,6 +47,7 @@
                             </ul>
 
                             <div class="border-b border-gray-200 py-4 text-sm text-gray-600">
+                                {{ block('step3', 'tutorials/consultations_index.tutorial.html.twig') }}
                                 {% if currentTag is not null %}
                                     <p><a href="{{ path('app_consultation', { 'filter': filter, 'cp': app.request.get('cp') }) }}" class="mr-2 pb-2 underline hover:no-underline text-gray-400 text-xs">Auswahl aufheben</a></p>
                                 {% endif %}

--- a/templates/statement/paragraph_text_part.html.twig
+++ b/templates/statement/paragraph_text_part.html.twig
@@ -17,9 +17,10 @@
             </a>
         </div>
 
-        <div class="col-span-4 lg:col-span-1 lg:col-start-1 lg:row-start-2 flex flex-row lg:flex-col items-end mb-2 lg:mb-0">
+        <div class="relative col-span-4 lg:col-span-1 lg:col-start-1 lg:row-start-2 flex flex-row lg:flex-col items-end mb-2 lg:mb-0">
 
             {% if app.user and is_granted('edit', statement) %}
+                {{ block('step4', 'tutorials/statement_show.tutorial.html.twig') }}
                 {% if hasChosen %}
                     <a href="{{ path('app_paragraph_edit', { 'uuid': paragraphContainer.paragraph.uuid, 'statement': statement.id, 'mod': paragraphContainer.chosenModification.modification.uuid }) }}" class="flex flex-row flex-nowrap items-center gap-2 opacity-60 hover:opacity-100 inline-block m-1 p-1.5 bg-gray-50 hover:bg-gray-100 border border-solid border-gray-300 text-gray-400 text-xs rounded-md">
                         Änderung vorschlagen <i class="fa-solid fa-edit"></i>
@@ -29,8 +30,6 @@
                         Änderung vorschlagen <i class="fa-solid fa-edit"></i>
                     </a>
                 {% endif %}
-
-
 
 
                 {% if hasChosen %}
@@ -124,6 +123,8 @@
                     </a>
                 </div>
                 {% endif %}
+
+                {{ block('step5', 'tutorials/statement_show.tutorial.html.twig') }}
 
             </div>
         </div>

--- a/templates/statement/show.html.twig
+++ b/templates/statement/show.html.twig
@@ -1,3 +1,4 @@
+{% set showTutorial = true %}
 {% extends 'layout-default.html.twig' %}
 
 {% set collapse = app.user is null or not is_granted('edit', statement) %}
@@ -48,6 +49,7 @@
             <h1 class="md:mt-2 text-2xl sm:text-3xl md:text-4xl xl:text-6xl font-bold tracking-tight text-gray-700">
                 {{ statement.name }}
             </h1>
+            {{ block('step1', 'tutorials/statement_show.tutorial.html.twig') }}
             {% if statement.public %}
                 {% if app.user %}
                     {% if is_granted('own', statement) %}
@@ -135,6 +137,7 @@
                                 #}
 
                             </div>
+                            {{ block('step2', 'tutorials/statement_show.tutorial.html.twig') }}
                         {% endif %}
                     {% endif %}
                 </div>
@@ -189,6 +192,7 @@
                                 <i class="fa-solid fa-pencil hidden md:inline-block"></i>
                                 <span class="ml-1">Intro Text hinzufügen</span>
                             </a>
+                            {{ block('step3', 'tutorials/statement_show.tutorial.html.twig') }}
                         </div>
                     {% endif %}
 

--- a/templates/tutorials/consultations_index.tutorial.html.twig
+++ b/templates/tutorials/consultations_index.tutorial.html.twig
@@ -1,0 +1,23 @@
+{% block step1 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {isFirst: true} %}
+        {% block content %}
+            Willkommen bei Demokratis. Dies ist eine kurze Einführung in die Funktionalitäten der Übersichtsseite für Vernehmlassungen.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step2 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {} %}
+        {% block content %}
+            Geben Sie hier einen Suchbegriff ein, um nach einem Vernehmlassungsverfahren zu suchen.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step3 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {isLast: true, positionLg: 'right'} %}
+        {% block content %}
+            Klicken Sie auf ein Schlagwort, um dazu passende Vernehmlassungen anzuzeigen.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/templates/tutorials/statement_show.tutorial.html.twig
+++ b/templates/tutorials/statement_show.tutorial.html.twig
@@ -1,0 +1,39 @@
+{% block step1 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {isFirst: true} %}
+        {% block content %}
+            In dieser Ansicht können Sie gemeinsam mit anderen eine Stellungnahme erarbeiten. Diese Einführung gibt Ihnen einen kurzen Überblick über die verfügbaren Funktionen.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step2 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {} %}
+        {% block content %}
+            Hier können Sie allgemeine Einstellungen zur Stellungnahme vornehmen und diese als Word-Datei exportieren.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step3 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {} %}
+        {% block content %}
+            Verfassen Sie einen einleitenden Text für Ihre Stellungnahme.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step4 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {positionLg: 'right'} %}
+        {% block content %}
+            Schlagen Sie eine Änderung für diesen Absatz vor. Andere Nutzer können diese Änderungen dann diskutieren und dann einen Vorschlag für die Stellungnahme auswählen.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block step5 %}
+    {% embed "tutorials/tutorialBubble.html.twig" with {isLast: true} %}
+        {% block content %}
+            Lesen Sie die Änderungsvorschläge, die bereits von anderen Nutzern gemacht wurden.
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/templates/tutorials/tutorialBubble.html.twig
+++ b/templates/tutorials/tutorialBubble.html.twig
@@ -1,0 +1,46 @@
+{% set styles = {
+    'right': ' after:border-t-transparent after:border-r-blue-400 after:border-b-transparent after:border-l-transparent after:mx-[-30px] after:my-3 left-full right-auto',
+    'left': ' after:border-t-transparent after:border-r-transparent after:border-b-transparent after:border-l-blue-400 after:mx-[-30px] after:my-3 left-auto right-full',
+    'bottom': ' after:border-t-transparent after:border-r-transparent after:border-b-blue-400 after:border-l-transparent after:my-[-30px] after:mx-8 left-auto right-auto',
+} %}
+<div class="relative">
+    <div data-tutorial-target="tutorialStep"
+         class="tutorialStep hidden absolute z-50 bg-white w-[30em] shadow-lg shadow-gray-400 m-4 flex flex-col
+        after:border-[16px] after:absolute after:w-0 after:h-0
+        after:border-t-transparent after:border-r-transparent after:border-b-blue-400 after:border-l-transparent after:my-[-30px] after:mx-8
+        left-auto right-auto top-0 bottom-auto
+        {% if positionLg|default == 'right' %}
+            lg:after:border-t-transparent lg:after:border-r-blue-400 lg:after:border-b-transparent lg:after:border-l-transparent lg:after:mx-[-30px] lg:after:my-3 lg:left-full lg:right-auto top-auto bottom-auto
+        {% endif %}
+    "
+    >
+        <div class="bg-blue-400 text-white font-bold p-4 flex flex-row">
+            <div>
+                <i class="fa-solid fa-fw fa-question-circle"></i> Einführung
+            </div>
+            <button type="button" data-action="tutorial#close" class="hover:bg-blue-300 p-2 -m-2 rounded-md ml-auto">
+                <i class="fa-regular fa-fw fa-close"></i>
+            </button>
+
+        </div>
+        <div class="p-4">
+            {% block content %}{% endblock %}
+        </div>
+        <div class="p-4 flex flex-row-reverse gap-2">
+            {% if not isLast|default %}
+                <button type="button" data-action="tutorial#next" class="bg-blue-400 hover:bg-blue-300 text-white p-2 rounded-md">
+                    Weiter <i class="fa-regular fa-fw fa-chevron-right"></i>
+                </button>
+            {% else %}
+                <button type="button" data-action="tutorial#close" class="bg-blue-400 hover:bg-blue-300 text-white p-2 rounded-md">
+                    Fertig
+                </button>
+            {% endif %}
+            {% if not isFirst|default %}
+                <button type="button" data-action="tutorial#prev" class="hover:bg-gray-100 p-2 rounded-md">
+                    <i class="fa-regular fa-fw fa-chevron-left"></i>
+                </button>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/templates/tutorials/tutorialBubble.html.twig
+++ b/templates/tutorials/tutorialBubble.html.twig
@@ -1,8 +1,3 @@
-{% set styles = {
-    'right': ' after:border-t-transparent after:border-r-blue-400 after:border-b-transparent after:border-l-transparent after:mx-[-30px] after:my-3 left-full right-auto',
-    'left': ' after:border-t-transparent after:border-r-transparent after:border-b-transparent after:border-l-blue-400 after:mx-[-30px] after:my-3 left-auto right-full',
-    'bottom': ' after:border-t-transparent after:border-r-transparent after:border-b-blue-400 after:border-l-transparent after:my-[-30px] after:mx-8 left-auto right-auto',
-} %}
 <div class="relative">
     <div data-tutorial-target="tutorialStep"
          class="tutorialStep hidden absolute z-50 bg-white w-[30em] shadow-lg shadow-gray-400 m-4 flex flex-col

--- a/templates/tutorials/tutorialBubble.html.twig
+++ b/templates/tutorials/tutorialBubble.html.twig
@@ -1,17 +1,18 @@
-<div class="relative">
+<div class="relative text-sm">
     <div data-tutorial-target="tutorialStep"
-         class="tutorialStep hidden absolute z-50 bg-white w-[30em] shadow-lg shadow-gray-400 m-4 flex flex-col
+         class="tutorialStep hidden absolute z-50 bg-white w-[30em] shadow-lg shadow-gray-400 md:m-4 flex flex-col
         after:border-[16px] after:absolute after:w-0 after:h-0
         after:border-t-transparent after:border-r-transparent after:border-b-blue-400 after:border-l-transparent after:my-[-30px] after:mx-8
         left-auto right-auto top-0 bottom-auto
         {% if positionLg|default == 'right' %}
             lg:after:border-t-transparent lg:after:border-r-blue-400 lg:after:border-b-transparent lg:after:border-l-transparent lg:after:mx-[-30px] lg:after:my-3 lg:left-full lg:right-auto top-auto bottom-auto
         {% endif %}
+        rounded-lg
     "
     >
-        <div class="bg-blue-400 text-white font-bold p-4 flex flex-row">
+        <div class="bg-blue-400 rounded-t-lg text-white font-bold p-4 flex flex-row text-base">
             <div>
-                <i class="fa-solid fa-fw fa-question-circle"></i> Einführung
+                Einführung
             </div>
             <button type="button" data-action="tutorial#close" class="hover:bg-blue-300 p-2 -m-2 rounded-md ml-auto">
                 <i class="fa-regular fa-fw fa-close"></i>
@@ -23,11 +24,11 @@
         </div>
         <div class="p-4 flex flex-row-reverse gap-2">
             {% if not isLast|default %}
-                <button type="button" data-action="tutorial#next" class="bg-blue-400 hover:bg-blue-300 text-white p-2 rounded-md">
+                <button type="button" data-action="tutorial#next" class="text-blue-500 hover:bg-gray-100 hover:text-blue-700 text-blue-400 p-2 rounded-md">
                     Weiter <i class="fa-regular fa-fw fa-chevron-right"></i>
                 </button>
             {% else %}
-                <button type="button" data-action="tutorial#close" class="bg-blue-400 hover:bg-blue-300 text-white p-2 rounded-md">
+                <button type="button" data-action="tutorial#close" class="text-blue-500 hover:bg-gray-100 hover:text-blue-700 text-blue-400 p-2 rounded-md">
                     Fertig
                 </button>
             {% endif %}


### PR DESCRIPTION
Simples System zum bauen von "Tutorials". Das sind Abfolgen von kleinen Hilfetexten in Sprechblasen, die auf ein Element auf der Seite verweisen.

Es gibt zwei Beispieltutorials im PR, in der Übersicht Vernehmlassungen und in der Ansicht Stellungnahme. Aktiviert werden sie über das (?) in der Menüleiste.

<img width="1221" alt="Bildschirmfoto 2023-04-27 um 22 42 35" src="https://user-images.githubusercontent.com/15876496/234986098-f77ed6f6-c934-4258-b407-bcb319f27130.png">
